### PR TITLE
サーバ起動時 json ファイルの参照先を変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ typings/
 /src/assets/_scss/_bootstrap/
 /src/assets/_scss/_font-awesome/
 /src/assets/_scss/_simple-line-icons/
+
+# data フォルダ
+/.data/
+!/.data/.gitkeep

--- a/server/index.js
+++ b/server/index.js
@@ -8,19 +8,20 @@ const writeFile = util.promisify(fs.writeFile);
 
 const rootPath = path.join(__dirname, '../');
 const htoocsPath = path.join(rootPath, 'htdocs');
-const scoreDataPath = path.join(htoocsPath, 'assets/js/score.json');
+const scoreDataPath = path.join(rootPath, '.data/score.json');
 
-// Routing
+// Static Files
 fastify.register(require('fastify-static'), {
   root: htoocsPath,
 });
-//
-fastify.get('/score', async (request, reply) => {
+// スコア参照
+fastify.get('/assets/js/score.json', async (request, reply) => {
+  console.log('ref file', scoreDataPath);
   const json = await readFile(scoreDataPath);
   reply.type('application/json').code(200);
   return JSON.parse(json);
 });
-//
+// スコア追加
 fastify.post('/score', async (request, reply) => {
   try {
     const data = await readFile(scoreDataPath);


### PR DESCRIPTION
Ref.  #7

実現方法変更
サーバ起動時 jsonファイル参照パスを別のデータフォルダを見に行くよう変更
staticファイル参照時はそのままjsonファイルを参照している